### PR TITLE
Standardise on showing beginning of blog post

### DIFF
--- a/src/contents/articles/hello-world.md
+++ b/src/contents/articles/hello-world.md
@@ -8,6 +8,7 @@ template: article.jade
 ### This is **namespace**
 
 Hi everyone, we're officially launching namespace - a club for software developers in Trinidad and Tobago. We're a movement to remove the silos of people scattered throughout the nation that prevents us from build a community. 
+<span class="more"></span>
 
 ## Why do we need a community?
 

--- a/src/contents/articles/namespace-is-here.md
+++ b/src/contents/articles/namespace-is-here.md
@@ -8,6 +8,7 @@ template: article.jade
 
 Yes! I know you read that already but I'm repeating it. Namespace is here
 and ready to shake a tail feather.
+<span class="more"></span>
 
 I felt I should make a post to explain Namespace as succinctly as possible, so here goes:
 

--- a/src/contents/articles/public-coding-roundup.md
+++ b/src/contents/articles/public-coding-roundup.md
@@ -6,6 +6,8 @@ template: article.jade
 ---
 
 On Saturday 30th May, Namespace hosted a public coding session. Public coding mirrors the coworking experience, a style of work where persons do independent work in a shared space.
+<span class="more"></span>
+
 The idea behind coworking is that there is inherent value to working alongside other individuals even if you’re not all working on the same things. It’s an effort by remote workers, freelancers and the like to preserve some of the benefits of traditional office work such as socializing, building relationships and fostering a sense of belonging outside the company walls.
 
 The Namespace team felt that the coworking model could be useful for software developers who often work on projects on their own in their spare time.  So members of the team met on the Indian Arrival Day holiday for a public coding session. Five of us occupied the M12 study room in UWI’s Student Activity Centre for five hours, temporarily converting it into a workspace for software developers. 

--- a/src/contents/articles/public_coding_30_may_2015.md
+++ b/src/contents/articles/public_coding_30_may_2015.md
@@ -7,7 +7,10 @@ template: article.jade
 
 Namespace will be doing *public coding* on the Indian Arrival Day holiday this Saturday. 
 What we call public coding is not a structured activity, it's just a get together for developers to work on their personal projects but in a shared space. 
+<span class="more"></span>
 It's an opportunity for you to meet and interact with your peers in the local software community while also getting stuff done.
 There are no requirements, just show up, say hi and get to work. 
+
 We would appreciate you stopping by even if you don't have anything to work on as we'd like to engage with as many people in our community as possible.
+
 We'll be meeting up at the Student Activity Centre at the UWI Campus in St. Augustine between 1pm and 6pm. Hope to see you there and have a Happy Indian Arrival Day holiday tomorrow.


### PR DESCRIPTION
Allow for a more consistent and compact home page by only showing the beginning of blog posts
